### PR TITLE
feat: explicitly recreate tab groups during restore

### DIFF
--- a/src/lib/restore.test.ts
+++ b/src/lib/restore.test.ts
@@ -2,33 +2,6 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { applyGroupsToWindow, closeAllWindows } from "./restore";
 import type { SnapshotGroup } from "./snapshot";
 
-function makeAutoGroup(id: number, windowId = 1): chrome.tabGroups.TabGroup {
-  return {
-    id,
-    windowId,
-    title: `Auto Group ${id}`,
-    color: "grey",
-    collapsed: false
-  } as chrome.tabGroups.TabGroup;
-}
-
-function makeTab(id: number, windowId: number, groupId: number): chrome.tabs.Tab {
-  return {
-    id,
-    windowId,
-    groupId,
-    index: id - 1,
-    url: `https://example.com/${id}`,
-    pinned: false,
-    active: false,
-    highlighted: false,
-    selected: false,
-    discarded: false,
-    autoDiscardable: true,
-    incognito: false
-  } as unknown as chrome.tabs.Tab;
-}
-
 function makeSnapshotGroup(overrides: Partial<SnapshotGroup> & Pick<SnapshotGroup, "tabIndexes">): SnapshotGroup {
   return {
     id: 1,
@@ -40,185 +13,6 @@ function makeSnapshotGroup(overrides: Partial<SnapshotGroup> & Pick<SnapshotGrou
   };
 }
 
-beforeEach(() => {
-  vi.resetAllMocks();
-});
-
-describe("applyGroupsToWindow", () => {
-  it("completes without error when no auto-created groups exist in the window", async () => {
-    const queryMock = vi.fn().mockResolvedValue([]);
-    const tabsQueryMock = vi.fn().mockResolvedValue([]);
-    const updateMock = vi.fn().mockResolvedValue({});
-
-    vi.stubGlobal("chrome", {
-      tabGroups: { query: queryMock, update: updateMock, TAB_GROUP_ID_NONE: -1 },
-      tabs: { query: tabsQueryMock }
-    });
-
-    const snapshotGroups: SnapshotGroup[] = [makeSnapshotGroup({ tabIndexes: [0, 1] })];
-    const tabIdMap = new Map([[0, 101], [1, 102]]);
-
-    await applyGroupsToWindow(1, snapshotGroups, tabIdMap);
-
-    expect(updateMock).not.toHaveBeenCalled();
-  });
-
-  it("completes without error when snapshotGroups is empty", async () => {
-    const queryMock = vi.fn().mockResolvedValue([makeAutoGroup(10)]);
-    const tabsQueryMock = vi.fn().mockResolvedValue([makeTab(101, 1, 10)]);
-    const updateMock = vi.fn().mockResolvedValue({});
-
-    vi.stubGlobal("chrome", {
-      tabGroups: { query: queryMock, update: updateMock, TAB_GROUP_ID_NONE: -1 },
-      tabs: { query: tabsQueryMock }
-    });
-
-    await applyGroupsToWindow(1, [], new Map());
-
-    expect(queryMock).not.toHaveBeenCalled();
-    expect(updateMock).not.toHaveBeenCalled();
-  });
-
-  it("calls update with correct title, color, and collapsed:true for matched group", async () => {
-    const autoGroup = makeAutoGroup(10);
-    const queryMock = vi.fn().mockResolvedValue([autoGroup]);
-    const tabsQueryMock = vi.fn().mockResolvedValue([
-      makeTab(101, 1, 10),
-      makeTab(102, 1, 10)
-    ]);
-    const updateMock = vi.fn().mockResolvedValue({});
-
-    vi.stubGlobal("chrome", {
-      tabGroups: { query: queryMock, update: updateMock, TAB_GROUP_ID_NONE: -1 },
-      tabs: { query: tabsQueryMock }
-    });
-
-    const snapshotGroups: SnapshotGroup[] = [
-      makeSnapshotGroup({ title: "Work", color: "blue", tabIndexes: [0, 1] })
-    ];
-    const tabIdMap = new Map([[0, 101], [1, 102]]);
-
-    await applyGroupsToWindow(1, snapshotGroups, tabIdMap);
-
-    expect(updateMock).toHaveBeenCalledOnce();
-    expect(updateMock).toHaveBeenCalledWith(10, { title: "Work", color: "blue", collapsed: true });
-  });
-
-  it("forces collapsed:true even when the snapshot group had collapsed:false", async () => {
-    const autoGroup = makeAutoGroup(20);
-    const queryMock = vi.fn().mockResolvedValue([autoGroup]);
-    const tabsQueryMock = vi.fn().mockResolvedValue([makeTab(201, 1, 20)]);
-    const updateMock = vi.fn().mockResolvedValue({});
-
-    vi.stubGlobal("chrome", {
-      tabGroups: { query: queryMock, update: updateMock, TAB_GROUP_ID_NONE: -1 },
-      tabs: { query: tabsQueryMock }
-    });
-
-    const snapshotGroups: SnapshotGroup[] = [
-      makeSnapshotGroup({ title: "Research", color: "red", collapsed: false, tabIndexes: [0] })
-    ];
-    const tabIdMap = new Map([[0, 201]]);
-
-    await applyGroupsToWindow(1, snapshotGroups, tabIdMap);
-
-    expect(updateMock).toHaveBeenCalledWith(20, expect.objectContaining({ collapsed: true }));
-  });
-
-  it("does NOT call update for an auto-created group that has no snapshot match", async () => {
-    // Two auto-created groups: group 10 matches snapshot, group 11 does not
-    const queryMock = vi.fn().mockResolvedValue([makeAutoGroup(10), makeAutoGroup(11)]);
-    const tabsQueryMock = vi.fn().mockResolvedValue([
-      makeTab(101, 1, 10),
-      makeTab(102, 1, 10),
-      makeTab(103, 1, 11) // tab 103 is in group 11, not in any snapshot group
-    ]);
-    const updateMock = vi.fn().mockResolvedValue({});
-
-    vi.stubGlobal("chrome", {
-      tabGroups: { query: queryMock, update: updateMock, TAB_GROUP_ID_NONE: -1 },
-      tabs: { query: tabsQueryMock }
-    });
-
-    const snapshotGroups: SnapshotGroup[] = [
-      makeSnapshotGroup({ title: "Work", color: "blue", tabIndexes: [0, 1] })
-      // No snapshot group for tabs at index 2
-    ];
-    const tabIdMap = new Map([[0, 101], [1, 102], [2, 103]]);
-
-    await applyGroupsToWindow(1, snapshotGroups, tabIdMap);
-
-    expect(updateMock).toHaveBeenCalledOnce();
-    expect(updateMock).toHaveBeenCalledWith(10, { title: "Work", color: "blue", collapsed: true });
-  });
-
-  it("correctly matches and updates multiple groups in the same window", async () => {
-    const queryMock = vi.fn().mockResolvedValue([makeAutoGroup(10), makeAutoGroup(20)]);
-    const tabsQueryMock = vi.fn().mockResolvedValue([
-      makeTab(101, 1, 10),
-      makeTab(102, 1, 10),
-      makeTab(201, 1, 20)
-    ]);
-    const updateMock = vi.fn().mockResolvedValue({});
-
-    vi.stubGlobal("chrome", {
-      tabGroups: { query: queryMock, update: updateMock, TAB_GROUP_ID_NONE: -1 },
-      tabs: { query: tabsQueryMock }
-    });
-
-    const snapshotGroups: SnapshotGroup[] = [
-      makeSnapshotGroup({ id: 1, title: "Work", color: "blue", tabIndexes: [0, 1] }),
-      makeSnapshotGroup({ id: 2, title: "Fun", color: "green", tabIndexes: [2] })
-    ];
-    const tabIdMap = new Map([[0, 101], [1, 102], [2, 201]]);
-
-    await applyGroupsToWindow(1, snapshotGroups, tabIdMap);
-
-    expect(updateMock).toHaveBeenCalledTimes(2);
-    expect(updateMock).toHaveBeenCalledWith(10, { title: "Work", color: "blue", collapsed: true });
-    expect(updateMock).toHaveBeenCalledWith(20, { title: "Fun", color: "green", collapsed: true });
-  });
-
-  it("silently skips snapshot groups whose tabs were all skipped (no created tab IDs)", async () => {
-    const queryMock = vi.fn().mockResolvedValue([makeAutoGroup(10)]);
-    const tabsQueryMock = vi.fn().mockResolvedValue([makeTab(101, 1, 10)]);
-    const updateMock = vi.fn().mockResolvedValue({});
-
-    vi.stubGlobal("chrome", {
-      tabGroups: { query: queryMock, update: updateMock, TAB_GROUP_ID_NONE: -1 },
-      tabs: { query: tabsQueryMock }
-    });
-
-    // Snapshot group refers to tabIndex 5, but that tab was skipped so it's not in the map
-    const snapshotGroups: SnapshotGroup[] = [
-      makeSnapshotGroup({ title: "Skipped", color: "yellow", tabIndexes: [5] })
-    ];
-    const tabIdMap = new Map<number, number>(); // empty — tab was skipped
-
-    await applyGroupsToWindow(1, snapshotGroups, tabIdMap);
-
-    expect(updateMock).not.toHaveBeenCalled();
-  });
-
-  it("queries with the correct windowId", async () => {
-    const queryMock = vi.fn().mockResolvedValue([]);
-    const tabsQueryMock = vi.fn().mockResolvedValue([]);
-    const updateMock = vi.fn().mockResolvedValue({});
-
-    vi.stubGlobal("chrome", {
-      tabGroups: { query: queryMock, update: updateMock, TAB_GROUP_ID_NONE: -1 },
-      tabs: { query: tabsQueryMock }
-    });
-
-    const snapshotGroups: SnapshotGroup[] = [makeSnapshotGroup({ tabIndexes: [0] })];
-    const tabIdMap = new Map([[0, 101]]);
-
-    await applyGroupsToWindow(42, snapshotGroups, tabIdMap);
-
-    expect(queryMock).toHaveBeenCalledWith({ windowId: 42 });
-  });
-});
-
 function makeWindow(id: number): chrome.windows.Window {
   return {
     id,
@@ -229,6 +23,163 @@ function makeWindow(id: number): chrome.windows.Window {
     state: "normal"
   } as chrome.windows.Window;
 }
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("applyGroupsToWindow", () => {
+  it("completes without error when snapshotGroups is empty", async () => {
+    const groupMock = vi.fn().mockResolvedValue(10);
+    const updateMock = vi.fn().mockResolvedValue({});
+
+    vi.stubGlobal("chrome", {
+      tabGroups: { update: updateMock },
+      tabs: { group: groupMock }
+    });
+
+    await applyGroupsToWindow(1, [], new Map());
+
+    expect(groupMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it("creates a group and applies title, color, and collapsed state", async () => {
+    const groupMock = vi.fn().mockResolvedValue(99);
+    const updateMock = vi.fn().mockResolvedValue({});
+
+    vi.stubGlobal("chrome", {
+      tabGroups: { update: updateMock },
+      tabs: { group: groupMock }
+    });
+
+    const snapshotGroups: SnapshotGroup[] = [
+      makeSnapshotGroup({ title: "Work", color: "blue", collapsed: false, tabIndexes: [0, 1] })
+    ];
+    const tabIdMap = new Map([[0, 101], [1, 102]]);
+
+    await applyGroupsToWindow(1, snapshotGroups, tabIdMap);
+
+    expect(groupMock).toHaveBeenCalledOnce();
+    expect(groupMock).toHaveBeenCalledWith({ tabIds: [101, 102], createProperties: { windowId: 1 } });
+    expect(updateMock).toHaveBeenCalledOnce();
+    expect(updateMock).toHaveBeenCalledWith(99, { title: "Work", color: "blue", collapsed: false });
+  });
+
+  it("restores a collapsed group with collapsed:true", async () => {
+    const groupMock = vi.fn().mockResolvedValue(55);
+    const updateMock = vi.fn().mockResolvedValue({});
+
+    vi.stubGlobal("chrome", {
+      tabGroups: { update: updateMock },
+      tabs: { group: groupMock }
+    });
+
+    const snapshotGroups: SnapshotGroup[] = [
+      makeSnapshotGroup({ title: "Research", color: "red", collapsed: true, tabIndexes: [0] })
+    ];
+    const tabIdMap = new Map([[0, 201]]);
+
+    await applyGroupsToWindow(1, snapshotGroups, tabIdMap);
+
+    expect(updateMock).toHaveBeenCalledWith(55, expect.objectContaining({ collapsed: true }));
+  });
+
+  it("restores multiple distinct tab groups with correct members and no cross-group contamination", async () => {
+    // group() returns different IDs per call
+    const groupMock = vi.fn()
+      .mockResolvedValueOnce(10)
+      .mockResolvedValueOnce(20);
+    const updateMock = vi.fn().mockResolvedValue({});
+
+    vi.stubGlobal("chrome", {
+      tabGroups: { update: updateMock },
+      tabs: { group: groupMock }
+    });
+
+    const snapshotGroups: SnapshotGroup[] = [
+      makeSnapshotGroup({ id: 1, title: "Work", color: "blue", collapsed: false, tabIndexes: [0, 1] }),
+      makeSnapshotGroup({ id: 2, title: "Fun", color: "green", collapsed: false, tabIndexes: [2] })
+    ];
+    const tabIdMap = new Map([[0, 101], [1, 102], [2, 201]]);
+
+    await applyGroupsToWindow(1, snapshotGroups, tabIdMap);
+
+    expect(groupMock).toHaveBeenCalledTimes(2);
+    expect(groupMock).toHaveBeenCalledWith({ tabIds: [101, 102], createProperties: { windowId: 1 } });
+    expect(groupMock).toHaveBeenCalledWith({ tabIds: [201], createProperties: { windowId: 1 } });
+
+    expect(updateMock).toHaveBeenCalledTimes(2);
+    expect(updateMock).toHaveBeenCalledWith(10, { title: "Work", color: "blue", collapsed: false });
+    expect(updateMock).toHaveBeenCalledWith(20, { title: "Fun", color: "green", collapsed: false });
+  });
+
+  it("only groups tabs that have a groupId — ungrouped tabs are left as-is", async () => {
+    // tabIndex 1 is ungrouped (not in any snapshot group)
+    const groupMock = vi.fn().mockResolvedValue(10);
+    const updateMock = vi.fn().mockResolvedValue({});
+
+    vi.stubGlobal("chrome", {
+      tabGroups: { update: updateMock },
+      tabs: { group: groupMock }
+    });
+
+    const snapshotGroups: SnapshotGroup[] = [
+      makeSnapshotGroup({ title: "Work", color: "blue", tabIndexes: [0] })
+      // tabIndex 1 is intentionally omitted → ungrouped
+    ];
+    const tabIdMap = new Map([[0, 101], [1, 102]]);
+
+    await applyGroupsToWindow(1, snapshotGroups, tabIdMap);
+
+    // Only tabId 101 should be grouped
+    expect(groupMock).toHaveBeenCalledOnce();
+    expect(groupMock).toHaveBeenCalledWith({ tabIds: [101], createProperties: { windowId: 1 } });
+    // tabId 102 is never passed to group()
+    const allTabIdsGrouped: number[] = groupMock.mock.calls.flatMap((call) => call[0].tabIds as number[]);
+    expect(allTabIdsGrouped).not.toContain(102);
+  });
+
+  it("silently skips snapshot groups whose tabs were all skipped (no created tab IDs)", async () => {
+    const groupMock = vi.fn().mockResolvedValue(10);
+    const updateMock = vi.fn().mockResolvedValue({});
+
+    vi.stubGlobal("chrome", {
+      tabGroups: { update: updateMock },
+      tabs: { group: groupMock }
+    });
+
+    // Snapshot group refers to tabIndex 5, but that tab was skipped so it's not in the map
+    const snapshotGroups: SnapshotGroup[] = [
+      makeSnapshotGroup({ title: "Skipped", color: "yellow", tabIndexes: [5] })
+    ];
+    const tabIdMap = new Map<number, number>(); // empty — tab was skipped
+
+    await applyGroupsToWindow(1, snapshotGroups, tabIdMap);
+
+    expect(groupMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it("uses the correct windowId when creating the group", async () => {
+    const groupMock = vi.fn().mockResolvedValue(10);
+    const updateMock = vi.fn().mockResolvedValue({});
+
+    vi.stubGlobal("chrome", {
+      tabGroups: { update: updateMock },
+      tabs: { group: groupMock }
+    });
+
+    const snapshotGroups: SnapshotGroup[] = [makeSnapshotGroup({ tabIndexes: [0] })];
+    const tabIdMap = new Map([[0, 101]]);
+
+    await applyGroupsToWindow(42, snapshotGroups, tabIdMap);
+
+    expect(groupMock).toHaveBeenCalledWith(expect.objectContaining({
+      createProperties: { windowId: 42 }
+    }));
+  });
+});
 
 describe("closeAllWindows", () => {
   it("calls windows.remove for each open window", async () => {

--- a/src/lib/restore.ts
+++ b/src/lib/restore.ts
@@ -19,9 +19,11 @@ export async function closeAllWindows(): Promise<void> {
 }
 
 /**
- * Queries the auto-created tab groups in a newly restored window, matches each
- * one to a SnapshotGroup by comparing tab membership, then applies the saved
- * title, color, and forces collapsed:true via chrome.tabGroups.update().
+ * Explicitly recreates tab groups in a newly restored window by calling
+ * chrome.tabs.group() for each SnapshotGroup, then applies the saved title,
+ * color, and collapsed state via chrome.tabGroups.update().
+ *
+ * Tabs that have no groupId in the snapshot are left ungrouped.
  *
  * @param windowId - The ID of the newly created window.
  * @param snapshotGroups - Groups captured from the original snapshot window.
@@ -36,67 +38,25 @@ export async function applyGroupsToWindow(
     return;
   }
 
-  const autoCreatedGroups = await chrome.tabGroups.query({ windowId });
-  if (autoCreatedGroups.length === 0) {
-    return;
-  }
-
-  // Build a map from auto-created group ID → set of tab IDs in that group
-  const autoGroupTabIds = new Map<number, Set<number>>();
-  for (const group of autoCreatedGroups) {
-    autoGroupTabIds.set(group.id, new Set<number>());
-  }
-
-  const allTabsInWindow = await chrome.tabs.query({ windowId });
-  for (const tab of allTabsInWindow) {
-    if (typeof tab.id === "number" && typeof tab.groupId === "number" && autoGroupTabIds.has(tab.groupId)) {
-      autoGroupTabIds.get(tab.groupId)!.add(tab.id);
-    }
-  }
-
-  // For each snapshot group, compute the set of created tab IDs it owns
   for (const snapshotGroup of snapshotGroups) {
-    const expectedTabIds = new Set<number>();
+    const tabIds: number[] = [];
     for (const tabIndex of snapshotGroup.tabIndexes) {
       const createdId = createdTabIdsByIndex.get(tabIndex);
       if (typeof createdId === "number") {
-        expectedTabIds.add(createdId);
+        tabIds.push(createdId);
       }
     }
 
-    if (expectedTabIds.size === 0) {
+    if (tabIds.length === 0) {
       continue;
     }
 
-    // Find the auto-created group whose tab-ID set matches the expected set
-    let matchedGroupId: number | undefined;
-    for (const [autoGroupId, tabIdSet] of autoGroupTabIds) {
-      if (setsEqual(tabIdSet, expectedTabIds)) {
-        matchedGroupId = autoGroupId;
-        break;
-      }
-    }
+    const newGroupId = await chrome.tabs.group({ tabIds, createProperties: { windowId } });
 
-    if (typeof matchedGroupId !== "number") {
-      continue;
-    }
-
-    await chrome.tabGroups.update(matchedGroupId, {
+    await chrome.tabGroups.update(newGroupId, {
       title: snapshotGroup.title,
       color: snapshotGroup.color,
-      collapsed: true
+      collapsed: snapshotGroup.collapsed
     });
   }
-}
-
-function setsEqual(a: Set<number>, b: Set<number>): boolean {
-  if (a.size !== b.size) {
-    return false;
-  }
-  for (const value of a) {
-    if (!b.has(value)) {
-      return false;
-    }
-  }
-  return true;
 }


### PR DESCRIPTION
Closes #11

## Summary
- Replaced the "wait for Chrome auto-created groups, match by tab membership" approach in `applyGroupsToWindow` with explicit calls to `chrome.tabs.group()` + `chrome.tabGroups.update()` for each `SnapshotGroup`
- Uses the snapshot's `tabIndexes` → real tab ID mapping built during `populateWindowTabs` to assign the correct tabs to each group
- Ungrouped tabs (not listed in any `SnapshotGroup.tabIndexes`) are left ungrouped
- `collapsed` state is now applied faithfully from the snapshot (previously hardcoded to `true`)
- Removed the no-longer-needed `chrome.tabGroups.query` + `chrome.tabs.query` tab-membership matching logic

## Test plan
- [ ] All 16 tests pass (`npm test`)
- [ ] Manual: open Chrome with regular (non-Saved) tab groups → save snapshot → restore → verify groups are recreated with correct title, color, and collapsed state
- [ ] Manual: restore twice without reloading extension — verify idempotency (no duplicate groups)
- [ ] Manual: snapshot with mixed grouped/ungrouped tabs → verify ungrouped tabs remain ungrouped after restore
- [ ] Manual: full Chrome restart with `restoreLastOnStartup` enabled — verify auto-restore fires exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)