### PR TITLE
fix: reuse auto-created tab groups to prevent duplicate bookmarks bar chips

### DIFF
--- a/src/lib/restore.test.ts
+++ b/src/lib/restore.test.ts
@@ -24,6 +24,34 @@ function makeWindow(id: number): chrome.windows.Window {
   } as chrome.windows.Window;
 }
 
+/** Build a minimal chrome.tabGroups.TabGroup stub */
+function makeTabGroup(id: number): chrome.tabGroups.TabGroup {
+  return {
+    id,
+    windowId: 1,
+    title: "",
+    color: "blue",
+    collapsed: false
+  } as chrome.tabGroups.TabGroup;
+}
+
+/** Build a minimal chrome.tabs.Tab stub */
+function makeTab(id: number, groupId: number): chrome.tabs.Tab {
+  return {
+    id,
+    groupId,
+    index: 0,
+    pinned: false,
+    highlighted: false,
+    windowId: 1,
+    active: false,
+    incognito: false,
+    selected: false,
+    discarded: false,
+    autoDiscardable: true
+  } as unknown as chrome.tabs.Tab;
+}
+
 beforeEach(() => {
   vi.resetAllMocks();
 });
@@ -32,25 +60,32 @@ describe("applyGroupsToWindow", () => {
   it("completes without error when snapshotGroups is empty", async () => {
     const groupMock = vi.fn().mockResolvedValue(10);
     const updateMock = vi.fn().mockResolvedValue({});
+    const tabGroupsQueryMock = vi.fn().mockResolvedValue([]);
+    const tabsQueryMock = vi.fn().mockResolvedValue([]);
 
     vi.stubGlobal("chrome", {
-      tabGroups: { update: updateMock },
-      tabs: { group: groupMock }
+      tabGroups: { update: updateMock, query: tabGroupsQueryMock },
+      tabs: { group: groupMock, query: tabsQueryMock }
     });
 
     await applyGroupsToWindow(1, [], new Map());
 
     expect(groupMock).not.toHaveBeenCalled();
     expect(updateMock).not.toHaveBeenCalled();
+    // Early return means query should not have been called either
+    expect(tabGroupsQueryMock).not.toHaveBeenCalled();
   });
 
-  it("creates a group and applies title, color, and collapsed state", async () => {
+  it("creates a group and applies title, color, and collapsed state when no auto-created group exists", async () => {
     const groupMock = vi.fn().mockResolvedValue(99);
     const updateMock = vi.fn().mockResolvedValue({});
+    // No auto-created groups in the window
+    const tabGroupsQueryMock = vi.fn().mockResolvedValue([]);
+    const tabsQueryMock = vi.fn().mockResolvedValue([]);
 
     vi.stubGlobal("chrome", {
-      tabGroups: { update: updateMock },
-      tabs: { group: groupMock }
+      tabGroups: { update: updateMock, query: tabGroupsQueryMock },
+      tabs: { group: groupMock, query: tabsQueryMock }
     });
 
     const snapshotGroups: SnapshotGroup[] = [
@@ -69,10 +104,12 @@ describe("applyGroupsToWindow", () => {
   it("restores a collapsed group with collapsed:true", async () => {
     const groupMock = vi.fn().mockResolvedValue(55);
     const updateMock = vi.fn().mockResolvedValue({});
+    const tabGroupsQueryMock = vi.fn().mockResolvedValue([]);
+    const tabsQueryMock = vi.fn().mockResolvedValue([]);
 
     vi.stubGlobal("chrome", {
-      tabGroups: { update: updateMock },
-      tabs: { group: groupMock }
+      tabGroups: { update: updateMock, query: tabGroupsQueryMock },
+      tabs: { group: groupMock, query: tabsQueryMock }
     });
 
     const snapshotGroups: SnapshotGroup[] = [
@@ -91,10 +128,13 @@ describe("applyGroupsToWindow", () => {
       .mockResolvedValueOnce(10)
       .mockResolvedValueOnce(20);
     const updateMock = vi.fn().mockResolvedValue({});
+    // No auto-created groups
+    const tabGroupsQueryMock = vi.fn().mockResolvedValue([]);
+    const tabsQueryMock = vi.fn().mockResolvedValue([]);
 
     vi.stubGlobal("chrome", {
-      tabGroups: { update: updateMock },
-      tabs: { group: groupMock }
+      tabGroups: { update: updateMock, query: tabGroupsQueryMock },
+      tabs: { group: groupMock, query: tabsQueryMock }
     });
 
     const snapshotGroups: SnapshotGroup[] = [
@@ -118,10 +158,12 @@ describe("applyGroupsToWindow", () => {
     // tabIndex 1 is ungrouped (not in any snapshot group)
     const groupMock = vi.fn().mockResolvedValue(10);
     const updateMock = vi.fn().mockResolvedValue({});
+    const tabGroupsQueryMock = vi.fn().mockResolvedValue([]);
+    const tabsQueryMock = vi.fn().mockResolvedValue([]);
 
     vi.stubGlobal("chrome", {
-      tabGroups: { update: updateMock },
-      tabs: { group: groupMock }
+      tabGroups: { update: updateMock, query: tabGroupsQueryMock },
+      tabs: { group: groupMock, query: tabsQueryMock }
     });
 
     const snapshotGroups: SnapshotGroup[] = [
@@ -143,10 +185,12 @@ describe("applyGroupsToWindow", () => {
   it("silently skips snapshot groups whose tabs were all skipped (no created tab IDs)", async () => {
     const groupMock = vi.fn().mockResolvedValue(10);
     const updateMock = vi.fn().mockResolvedValue({});
+    const tabGroupsQueryMock = vi.fn().mockResolvedValue([]);
+    const tabsQueryMock = vi.fn().mockResolvedValue([]);
 
     vi.stubGlobal("chrome", {
-      tabGroups: { update: updateMock },
-      tabs: { group: groupMock }
+      tabGroups: { update: updateMock, query: tabGroupsQueryMock },
+      tabs: { group: groupMock, query: tabsQueryMock }
     });
 
     // Snapshot group refers to tabIndex 5, but that tab was skipped so it's not in the map
@@ -164,10 +208,12 @@ describe("applyGroupsToWindow", () => {
   it("uses the correct windowId when creating the group", async () => {
     const groupMock = vi.fn().mockResolvedValue(10);
     const updateMock = vi.fn().mockResolvedValue({});
+    const tabGroupsQueryMock = vi.fn().mockResolvedValue([]);
+    const tabsQueryMock = vi.fn().mockResolvedValue([]);
 
     vi.stubGlobal("chrome", {
-      tabGroups: { update: updateMock },
-      tabs: { group: groupMock }
+      tabGroups: { update: updateMock, query: tabGroupsQueryMock },
+      tabs: { group: groupMock, query: tabsQueryMock }
     });
 
     const snapshotGroups: SnapshotGroup[] = [makeSnapshotGroup({ tabIndexes: [0] })];
@@ -178,6 +224,136 @@ describe("applyGroupsToWindow", () => {
     expect(groupMock).toHaveBeenCalledWith(expect.objectContaining({
       createProperties: { windowId: 42 }
     }));
+  });
+
+  // --- New tests for hybrid auto-created group detection ---
+
+  it("reuses an auto-created group (Saved Tab Group instance) and does NOT call chrome.tabs.group()", async () => {
+    const groupMock = vi.fn();
+    const updateMock = vi.fn().mockResolvedValue({});
+
+    // Chrome has already auto-created group 77 for the restored tabs
+    const autoGroup = makeTabGroup(77);
+    const tabGroupsQueryMock = vi.fn().mockResolvedValue([autoGroup]);
+    // chrome.tabs.query({ windowId, groupId: 77 }) returns tabs 101 and 102
+    const tabsQueryMock = vi.fn().mockResolvedValue([makeTab(101, 77), makeTab(102, 77)]);
+
+    vi.stubGlobal("chrome", {
+      tabGroups: { update: updateMock, query: tabGroupsQueryMock },
+      tabs: { group: groupMock, query: tabsQueryMock }
+    });
+
+    const snapshotGroups: SnapshotGroup[] = [
+      makeSnapshotGroup({ title: "Work", color: "blue", collapsed: false, tabIndexes: [0, 1] })
+    ];
+    const tabIdMap = new Map([[0, 101], [1, 102]]);
+
+    await applyGroupsToWindow(1, snapshotGroups, tabIdMap);
+
+    // Should NOT have called chrome.tabs.group() — group was auto-created
+    expect(groupMock).not.toHaveBeenCalled();
+    // Should have called update on the existing auto-created group
+    expect(updateMock).toHaveBeenCalledOnce();
+    expect(updateMock).toHaveBeenCalledWith(77, { title: "Work", color: "blue", collapsed: false });
+  });
+
+  it("falls back to explicit chrome.tabs.group() when no auto-created group matches (regular non-saved group)", async () => {
+    const groupMock = vi.fn().mockResolvedValue(55);
+    const updateMock = vi.fn().mockResolvedValue({});
+
+    // No auto-created groups at all
+    const tabGroupsQueryMock = vi.fn().mockResolvedValue([]);
+    const tabsQueryMock = vi.fn().mockResolvedValue([]);
+
+    vi.stubGlobal("chrome", {
+      tabGroups: { update: updateMock, query: tabGroupsQueryMock },
+      tabs: { group: groupMock, query: tabsQueryMock }
+    });
+
+    const snapshotGroups: SnapshotGroup[] = [
+      makeSnapshotGroup({ title: "Research", color: "red", collapsed: true, tabIndexes: [0] })
+    ];
+    const tabIdMap = new Map([[0, 201]]);
+
+    await applyGroupsToWindow(1, snapshotGroups, tabIdMap);
+
+    // Must create a new group explicitly
+    expect(groupMock).toHaveBeenCalledOnce();
+    expect(groupMock).toHaveBeenCalledWith({ tabIds: [201], createProperties: { windowId: 1 } });
+    // Must update the newly created group
+    expect(updateMock).toHaveBeenCalledOnce();
+    expect(updateMock).toHaveBeenCalledWith(55, { title: "Research", color: "red", collapsed: true });
+  });
+
+  it("handles mixed scenario: reuses auto-created group for saved tabs, creates new group for regular tabs", async () => {
+    // group() is only called for the regular group (snapshot group 2)
+    const groupMock = vi.fn().mockResolvedValue(88);
+    const updateMock = vi.fn().mockResolvedValue({});
+
+    // One auto-created group (id 77) contains tabs 101 and 102 (snapshot group 1)
+    const autoGroup = makeTabGroup(77);
+    const tabGroupsQueryMock = vi.fn().mockResolvedValue([autoGroup]);
+
+    // tabs.query is called per auto-created group per snapshot group being checked.
+    // For snapshot group 1 (tabs 101, 102): query returns tabs 101 and 102 → match found.
+    // For snapshot group 2 (tab 201): the auto-group check queries and returns 101,102 → no match.
+    const tabsQueryMock = vi.fn()
+      .mockResolvedValueOnce([makeTab(101, 77), makeTab(102, 77)]) // check for group 1
+      .mockResolvedValueOnce([makeTab(101, 77), makeTab(102, 77)]); // check for group 2 (no match)
+
+    vi.stubGlobal("chrome", {
+      tabGroups: { update: updateMock, query: tabGroupsQueryMock },
+      tabs: { group: groupMock, query: tabsQueryMock }
+    });
+
+    const snapshotGroups: SnapshotGroup[] = [
+      makeSnapshotGroup({ id: 1, title: "Saved Work", color: "blue", collapsed: false, tabIndexes: [0, 1] }),
+      makeSnapshotGroup({ id: 2, title: "Regular Fun", color: "green", collapsed: false, tabIndexes: [2] })
+    ];
+    const tabIdMap = new Map([[0, 101], [1, 102], [2, 201]]);
+
+    await applyGroupsToWindow(1, snapshotGroups, tabIdMap);
+
+    // chrome.tabs.group() called only once — for the regular group (snapshot group 2)
+    expect(groupMock).toHaveBeenCalledOnce();
+    expect(groupMock).toHaveBeenCalledWith({ tabIds: [201], createProperties: { windowId: 1 } });
+
+    // update called twice: once for auto-created group 77, once for newly created group 88
+    expect(updateMock).toHaveBeenCalledTimes(2);
+    expect(updateMock).toHaveBeenCalledWith(77, { title: "Saved Work", color: "blue", collapsed: false });
+    expect(updateMock).toHaveBeenCalledWith(88, { title: "Regular Fun", color: "green", collapsed: false });
+  });
+
+  it("ungrouped tabs remain ungrouped even when auto-created groups are present", async () => {
+    const groupMock = vi.fn().mockResolvedValue(10);
+    const updateMock = vi.fn().mockResolvedValue({});
+
+    // An auto-created group exists but it only matches tab 101 (snapshot group covers tabIndex 0 only)
+    const autoGroup = makeTabGroup(77);
+    const tabGroupsQueryMock = vi.fn().mockResolvedValue([autoGroup]);
+    const tabsQueryMock = vi.fn().mockResolvedValue([makeTab(101, 77)]);
+
+    vi.stubGlobal("chrome", {
+      tabGroups: { update: updateMock, query: tabGroupsQueryMock },
+      tabs: { group: groupMock, query: tabsQueryMock }
+    });
+
+    const snapshotGroups: SnapshotGroup[] = [
+      makeSnapshotGroup({ title: "Work", color: "blue", tabIndexes: [0] })
+      // tabIndex 1 (tab 102) is ungrouped — not in any snapshot group
+    ];
+    const tabIdMap = new Map([[0, 101], [1, 102]]);
+
+    await applyGroupsToWindow(1, snapshotGroups, tabIdMap);
+
+    // Auto-created group matched for tab 101 → no chrome.tabs.group() call
+    expect(groupMock).not.toHaveBeenCalled();
+    expect(updateMock).toHaveBeenCalledOnce();
+    expect(updateMock).toHaveBeenCalledWith(77, { title: "Work", color: "blue", collapsed: false });
+
+    // tab 102 was never passed to group() — it stays ungrouped
+    const allTabIdsGrouped: number[] = groupMock.mock.calls.flatMap((call) => call[0].tabIds as number[]);
+    expect(allTabIdsGrouped).not.toContain(102);
   });
 });
 

--- a/src/lib/restore.ts
+++ b/src/lib/restore.ts
@@ -19,9 +19,43 @@ export async function closeAllWindows(): Promise<void> {
 }
 
 /**
- * Explicitly recreates tab groups in a newly restored window by calling
- * chrome.tabs.group() for each SnapshotGroup, then applies the saved title,
- * color, and collapsed state via chrome.tabGroups.update().
+ * Finds an existing auto-created tab group in the window that contains exactly
+ * the given set of tab IDs. Returns the group ID if found, or undefined.
+ *
+ * This is used to detect Saved Tab Group instances that Chrome automatically
+ * creates when tabs belonging to a Saved Tab Group are opened, so that restore
+ * can reuse those groups instead of creating new ones (which would cause
+ * duplicate chips in the bookmarks bar).
+ */
+async function findAutoCreatedGroup(
+  windowId: number,
+  expectedTabIds: Set<number>,
+  autoCreatedGroups: chrome.tabGroups.TabGroup[]
+): Promise<number | undefined> {
+  for (const group of autoCreatedGroups) {
+    const tabsInGroup = await chrome.tabs.query({ windowId, groupId: group.id });
+    const groupTabIds = new Set(tabsInGroup.map((t) => t.id as number));
+
+    if (
+      groupTabIds.size === expectedTabIds.size &&
+      [...expectedTabIds].every((id) => groupTabIds.has(id))
+    ) {
+      return group.id;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Applies tab groups to a newly restored window using a hybrid strategy:
+ *
+ * 1. After tabs are created, query Chrome for any auto-created groups in the
+ *    window (e.g., Saved Tab Group instances Chrome instantiated automatically).
+ * 2. For each SnapshotGroup, check if an auto-created group already contains
+ *    exactly the expected tabs. If so, reuse that group (skip chrome.tabs.group(),
+ *    call chrome.tabGroups.update() on the existing group).
+ * 3. If no matching auto-created group is found, fall back to explicitly calling
+ *    chrome.tabs.group() to create a new group, then chrome.tabGroups.update().
  *
  * Tabs that have no groupId in the snapshot are left ungrouped.
  *
@@ -38,6 +72,9 @@ export async function applyGroupsToWindow(
     return;
   }
 
+  // Query all auto-created groups in the window once before the loop.
+  const autoCreatedGroups = await chrome.tabGroups.query({ windowId });
+
   for (const snapshotGroup of snapshotGroups) {
     const tabIds: number[] = [];
     for (const tabIndex of snapshotGroup.tabIndexes) {
@@ -51,9 +88,19 @@ export async function applyGroupsToWindow(
       continue;
     }
 
-    const newGroupId = await chrome.tabs.group({ tabIds, createProperties: { windowId } });
+    const expectedTabIds = new Set(tabIds);
+    const existingGroupId = await findAutoCreatedGroup(windowId, expectedTabIds, autoCreatedGroups);
 
-    await chrome.tabGroups.update(newGroupId, {
+    let targetGroupId: number;
+    if (existingGroupId !== undefined) {
+      // Reuse the auto-created group — do NOT call chrome.tabs.group()
+      targetGroupId = existingGroupId;
+    } else {
+      // No matching auto-created group; explicitly create a new one
+      targetGroupId = await chrome.tabs.group({ tabIds, createProperties: { windowId } });
+    }
+
+    await chrome.tabGroups.update(targetGroupId, {
       title: snapshotGroup.title,
       color: snapshotGroup.color,
       collapsed: snapshotGroup.collapsed


### PR DESCRIPTION
Closes #13

## Summary
- Adds hybrid group detection logic to `applyGroupsToWindow` in `src/lib/restore.ts`
- After tabs are created, queries `chrome.tabGroups.query({ windowId })` to detect auto-created groups (e.g., Saved Tab Group instances Chrome instantiates automatically)
- For each snapshot group, checks if an existing auto-created group already contains exactly the expected tab IDs; if so, reuses that group instead of calling `chrome.tabs.group()` again
- Falls back to explicit `chrome.tabs.group()` creation for regular (non-saved) groups where Chrome did not auto-create a group
- Adds four new tests covering: auto-created group reuse, explicit creation fallback, mixed scenario, and ungrouped tabs staying ungrouped

## Test plan
- [ ] All 20 tests pass (`npm test`)
- [ ] Manual: restore a snapshot containing Saved Tab Group URLs — bookmarks bar chip count does not increase
- [ ] Manual: restore twice in a row — chip count unchanged after second restore (idempotency)
- [ ] Manual: regular (non-saved) tab groups are still explicitly created with correct title, color, and collapsed state
- [ ] Manual: ungrouped tabs remain ungrouped after restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)